### PR TITLE
Run as a Docker image, docker compose file, calculate distance if not provided ads-b

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM php
+LABEL maintainer "Die Peter Pan <diepeterpan@gmail.com>"
+
+RUN apt-get update && apt-get install -y curl cron bash nano
+
+COPY . /usr/src/myapp
+WORKDIR /usr/src/myapp
+
+COPY cronfile /etc/cron.d/cronfile
+RUN chmod 0644 /etc/cron.d/cronfile
+RUN crontab /etc/cron.d/cronfile
+
+ENTRYPOINT ["/usr/sbin/cron", "-f"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The script gets the data from an existing readsb or dump1090 installation (`airc
 <img src="/screenshots/telegramMessage.png" alt="Telegram message">  
 <sub><a href="https://www.planespotters.net/photo/1304779/9m-mub-malaysia-airlines-airbus-a330-223f" title="Photo Source">Photo Source</a></sub>
 
+
 When the (`aircraft.json`) don't contain the distance to the ADS-B station but do contain the position of the aircraft the distance can be calculated by providing the base station coordinates in the config file.
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The script gets the data from an existing readsb or dump1090 installation (`airc
 <img src="/screenshots/telegramMessage.png" alt="Telegram message">  
 <sub><a href="https://www.planespotters.net/photo/1304779/9m-mub-malaysia-airlines-airbus-a330-223f" title="Photo Source">Photo Source</a></sub>
 
+When the (`aircraft.json`) don't contain the distance to the ADS-B station but do contain the position of the aircraft the distance can be calculated by providing the base station coordinates in the config file.
+
 ## Dependencies
 Install the dependencies via:  
 `sudo apt install curl php-cli php-json php-curl -y`  
@@ -76,6 +78,8 @@ Restart readsb:
 Create docker image
 
 `docker build -t adsbtelegramnotify .`
+
+a Docker compose file is provided as an example of running this as a stack in e.g. Portainer. The example file maps in the config file as well as the decoded ADS-B file location.
 
 ## Contribute
 If you want to contribute to the project, you are welcome to do the translations into your local language. But no matter what you want to contribute, just send a PR and I'll take a look at it.

--- a/README.md
+++ b/README.md
@@ -72,5 +72,10 @@ DECODER_OPTIONS="--max-range 450 --write-json-every 1 --db-file /usr/local/share
 Restart readsb:  
 `sudo systemctl restart readsb`
 
+## Docker
+Create docker image
+
+`docker build -t adsbtelegramnotify .`
+
 ## Contribute
 If you want to contribute to the project, you are welcome to do the translations into your local language. But no matter what you want to contribute, just send a PR and I'll take a look at it.

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,11 @@
+version: "2.1"
+services:
+  adsbtelegramnotify:
+    image: adsbtelegramnotify:latest
+    container_name: adsbtelegramnotify
+    environment:
+      - TZ=Africa/Johannesburg
+    volumes:
+      - /opt/adsbtelegramnotify/config.php:/usr/src/myapp/includes/config.php:ro
+      - /opt/adsbtelegramnotify/dump1090-fa/:/run/readsb/:ro
+    restart: unless-stopped

--- a/cronfile
+++ b/cronfile
@@ -1,0 +1,1 @@
+* * * * * /usr/local/bin/php /usr/src/myapp/notifier.php > /proc/1/fd/1 2>&1

--- a/includes/config.template.php
+++ b/includes/config.template.php
@@ -12,6 +12,18 @@
  */
 
 /**
+ * Base station location
+ *
+ * When the aircraft.json don't contain the distance from the base station we can calculate it based
+ * on the location provided
+ * e.g.  -23.70132930423978 and 28.442266675589366
+ *
+ * @var float
+ */
+$stationlat = -23.70132930423978;
+$stationlon = 28.442266675589366;
+
+/**
  * Timezone
  * 
  * The timezone to be used in the notifications. Use the "TZ database name" from the list linked below:

--- a/includes/locales/de.php
+++ b/includes/locales/de.php
@@ -59,6 +59,7 @@ $lang['notifier']['aircraftUpdated'] = '%s bereits gesehen, Zeitpunkt der letzte
 $lang['notifier']['aircraftWrongDbFlag'] = '%s hat ein unerwünschtes dbFlag.';
 $lang['notifier']['aircraftSkipWithoutReg'] = '%s wurde übersprungen, da keine Registrierung ermittelt werden konnte.';
 $lang['notifier']['newAircraft'] = '%s neu im Überwachungsradius, wird benachrichtigt.';
+$lang['notifier']['aircraftCalcDistance'] = 'Berechnete Distanz %s.';
 
 // Planespotters API
 $lang['notifier']['planespottersApiCall'] = 'Frage Foto bei planespotters.net an.';

--- a/includes/locales/en.php
+++ b/includes/locales/en.php
@@ -59,6 +59,7 @@ $lang['notifier']['aircraftUpdated'] = '%s already seen, time of last sighting u
 $lang['notifier']['aircraftWrongDbFlag'] = '%s has an unwanted dbFlag.';
 $lang['notifier']['aircraftSkipWithoutReg'] = '%s was skipped because no registration could be determined.';
 $lang['notifier']['newAircraft'] = '%s new in the monitoring radius, will be notified.';
+$lang['notifier']['aircraftCalcDistance'] = 'Calculated distance %s.';
 
 // Planespotters API
 $lang['notifier']['planespottersApiCall'] = 'Request photo at planespotters.net.';

--- a/notifier.php
+++ b/notifier.php
@@ -169,6 +169,28 @@ if(!empty($aircrafts)) {
     /**
      * Check if the distance from the aircraft to the station is within the configured radius.
      */
+    if(empty($aircraft['r_dst']))
+    {
+      if(!empty($aircraft['lat']))
+      {
+        /* Let's calculate the distance */
+        $rad = M_PI / 180;
+        $lat1 = $aircraft['lat'];
+        $lon1 = $aircraft['lon'];
+
+        $lat2 = $stationlat;
+        $lon2 = $stationlon;
+
+        $r_dst =  acos(sin($lat2*$rad) * sin($lat1*$rad) + cos($lat2*$rad) * cos($lat1*$rad) * cos($lon2*$rad - $lon1*$rad)) * 6371;// Kilometers
+
+        if($useMetric !== FALSE) {
+          $r_dst = $r_dst * 0.539956803;
+        }
+        $aircraft['r_dst'] = $r_dst;
+        echo logEcho(sprintf($lang['notifier']['aircraftCalcDistance'], $aircraft['r_dst']), 'INFO', COLOR_INFO);
+       }
+    }
+
     if(empty($aircraft['r_dst']) OR (!is_numeric($aircraft['r_dst']) OR $aircraft['r_dst'] > $radius)) {
       echo logEcho(sprintf($lang['notifier']['aircraftOutOfRange'], $aircraft['hex']), 'INFO', COLOR_INFO);
       continue;
@@ -273,7 +295,7 @@ if(!empty($aircrafts)) {
        * Check if the altitude is available and should be posted.
        */
       if(!empty($aircraft[$altType]) AND $showAlt === TRUE) {
-        $text.= sprintf($lang['notifier']['aircraftAlt'], number_format(($useMetric ? ($aircraft[$altType]/3.28084) : $aircraft[$altType]), 0, '.', '.'), ($useMetric ? 'm' : 'ft'));
+        $text.= sprintf($lang['notifier']['aircraftAlt'], number_format(($useMetric ? ($aircraft[$altType]/3.28084) : $aircraft[$altType]), 0, '.'), ($useMetric ? 'm' : 'ft'));
       }
 
       /**


### PR DESCRIPTION
Provide file to create Docker image where notifier is run every minute using cron.  An example docker-compose file is provided which can be used in e.g. Portainer, the config file, and ads-b decoded files can be mapped in.

When the ads-b decoded files don't contain the distance (like in my case) it can be calculated by providing the base station location in the config file.

Fix minor annoyance where the decimal point is used as a thousands separator and in South Africa that reads then funky.